### PR TITLE
版本->espressif32@~3.5.0

### DIFF
--- a/2.Firmware/PlatformIO/Peak-ESP32-fw(6050)/lib/SD/src/sd_diskio.cpp
+++ b/2.Firmware/PlatformIO/Peak-ESP32-fw(6050)/lib/SD/src/sd_diskio.cpp
@@ -1,6 +1,6 @@
 #include "sd_diskio.h"
 #include "lvgl.h"
-#include "diskio_impl.h"
+
 extern "C" {
 #include "diskio.h"
 #include "ffconf.h"

--- a/2.Firmware/PlatformIO/Peak-ESP32-fw(6050)/platformio.ini
+++ b/2.Firmware/PlatformIO/Peak-ESP32-fw(6050)/platformio.ini
@@ -10,11 +10,10 @@
 
 
 [env:pico32]
-platform = espressif32
+platform = espressif32@~3.5.0
 board = pico32
 framework = arduino
 board_build.partitions = min_spiffs.csv
-
 
 
 upload_speed = 921600

--- a/2.Firmware/PlatformIO/Peak-ESP32-fw(6050)/src/HAL/HAL.h
+++ b/2.Firmware/PlatformIO/Peak-ESP32-fw(6050)/src/HAL/HAL.h
@@ -6,7 +6,7 @@
 #include "HAL_Def.h"
 #include "App/Configs/Config.h"
 #include "CommonMacro.h"
-#include "FreeRTOS/FreeRTOS.h"
+#include "FreeRTOS.h"
 
 namespace HAL
 {

--- a/2.Firmware/PlatformIO/Peak-ESP32-fw/platformio.ini
+++ b/2.Firmware/PlatformIO/Peak-ESP32-fw/platformio.ini
@@ -10,13 +10,12 @@
 
 
 [env:pico32]
-platform = espressif32
+platform = espressif32@~3.5.0
 board = pico32
 framework = arduino
 board_build.partitions = min_spiffs.csv
 
 
-upload_port = COM14
 upload_speed = 921600
 
 monitor_speed = 115200

--- a/2.Firmware/PlatformIO/README.md
+++ b/2.Firmware/PlatformIO/README.md
@@ -1,9 +1,11 @@
+由于PlatformIO 的ESP32包更新太快新版编译又会报错，所以指定工程版本3.5.0（platform = espressif32@~3.5.0）
+
 Peak-ESP32-fw(6050)      修改9250程序为6050
 
-上一个版本在最新的platformio框架会报FreeRTOS路径错误和sd库中定义错误
+~~上一个版本在最新的platformio框架会报FreeRTOS路径错误和sd库中定义错误~~
 
-由于platformio框架版本问题会报的错误解决方法：
+~~由于platformio框架版本问题会报的错误解决方法：~~
 
-HAL.h 文件  \#include "FreeRTOS.h"改为 \#include "FreeRTOS/FreeRTOS.h"
+~~HAL.h 文件  \#include "FreeRTOS.h"改为 \#include "FreeRTOS/FreeRTOS.h"~~
 
-lib/SD/src/sd_diskio.cpp   添加头文件 \#include "diskio_impl.h"
+~~lib/SD/src/sd_diskio.cpp   添加头文件 \#include "diskio_impl.h"~~


### PR DESCRIPTION
由于PlatformIO 的ESP32包更新太快新版编译又会报错，所以指定工程版本3.5.0